### PR TITLE
update the catch2 version to v2.13.5

### DIFF
--- a/scripts/install_dependencies.py
+++ b/scripts/install_dependencies.py
@@ -101,7 +101,7 @@ def install_catch2(install_directory, tmp_directory, architecture, clear=False):
     cleanup_tmp_dir(catch2_tmp_directory)
 
     subprocess.run(
-        "git clone https://github.com/catchorg/Catch2.git --depth 1 --branch v2.12.2",
+        "git clone https://github.com/catchorg/Catch2.git --depth 1 --branch v2.13.5",
         cwd=tmp_directory,
         shell=True,
         check=True,


### PR DESCRIPTION
I'm hitting a problem when I try to build on my Ubuntu 22.04 machine.  The root-cause is described here:

https://github.com/catchorg/Catch2/issues/2421

Updating to catch2 v2.13.5 fixes the error, as described in the issue.

Signed-off-by: Ben Ashbaugh <ben.ashbaugh@intel.com>